### PR TITLE
Don't warn about absolute URLs

### DIFF
--- a/lib/openstax/content/archive.rb
+++ b/lib/openstax/content/archive.rb
@@ -28,10 +28,6 @@ class OpenStax::Content::Archive
     end
 
     if uri.absolute?
-      OpenStax::Content.logger.warn do
-        "#{self.class.name} received an unexpected absolute URL in url_for: \"#{object}\""
-      end
-
       # Force absolute URLs to be https
       uri.scheme = 'https'
       return uri.to_s

--- a/lib/openstax/content/version.rb
+++ b/lib/openstax/content/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Content
-    VERSION = '0.2.1'
+    VERSION = '0.2.2'
   end
 end


### PR DESCRIPTION
 Pages use those when fetching the full hash