### PR TITLE
Added min_code_version and committed_at to books and set them from the ABL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 0 * * 0' # weekly
 
 jobs:
   rspec:

--- a/lib/openstax/content/abl.rb
+++ b/lib/openstax/content/abl.rb
@@ -71,7 +71,9 @@ class OpenStax::Content::Abl
               uuid: book[:uuid],
               version: version[:commit_sha][0..6],
               slug: book[:slug],
-              style: book[:style]
+              style: book[:style],
+              min_code_version: version[:min_code_version],
+              committed_at: commit_metadata[:committed_at]
             )
           end
         end

--- a/lib/openstax/content/book.rb
+++ b/lib/openstax/content/book.rb
@@ -1,3 +1,4 @@
+require 'forwardable'
 require_relative 'book_part'
 
 class OpenStax::Content::Book

--- a/lib/openstax/content/book.rb
+++ b/lib/openstax/content/book.rb
@@ -3,9 +3,12 @@ require_relative 'book_part'
 class OpenStax::Content::Book
   extend Forwardable
 
-  attr_reader :archive, :uuid, :version, :slug, :style
+  attr_reader :archive, :uuid, :version, :slug, :style, :min_code_version, :committed_at
 
-  def initialize(archive:, uuid:, version:, url: nil, hash: nil, slug: nil, style: nil)
+  def initialize(
+    archive:, uuid:, version:,
+    url: nil, hash: nil, slug: nil, style: nil, min_code_version: nil, committed_at: nil
+  )
     @archive = archive
     @uuid = uuid
     @version = version
@@ -13,6 +16,12 @@ class OpenStax::Content::Book
     @hash = hash
     @slug = slug
     @style = style
+    @min_code_version = min_code_version
+    @committed_at = committed_at
+  end
+
+  def valid?
+    min_code_version.nil? || min_code_version <= archive.version
   end
 
   def url

--- a/lib/openstax/content/version.rb
+++ b/lib/openstax/content/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Content
-    VERSION = '1.2.0'
+    VERSION = '1.3.0'
   end
 end

--- a/spec/openstax/content/book_spec.rb
+++ b/spec/openstax/content/book_spec.rb
@@ -27,4 +27,13 @@ RSpec.describe OpenStax::Content::Book do
     expect(book.root_book_part).to receive(:all_pages).and_return(all_pages)
     expect(book.all_pages).to eq all_pages
   end
+
+  it 'knows if the version plus archive version combination is valid or not' do
+    expect(book).to be_valid
+    book.instance_variable_set('@min_code_version', MINI_BOOK_ARCHIVE_VERSION)
+    expect(book).to be_valid
+    new_time = Time.strptime(MINI_BOOK_ARCHIVE_VERSION, '%Y%m%d.%H%M%S') + 1
+    book.instance_variable_set('@min_code_version', new_time.strftime('%Y%m%d.%H%M%S'))
+    expect(book).not_to be_valid
+  end
 end


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2002
To allow us to compare the min_code_version with the archive pipeline version we are trying